### PR TITLE
Sets all hooks to use a single mod ID internally

### DIFF
--- a/1.12.2_LegacyFabric/src/main/resources/fabric.mod.json
+++ b/1.12.2_LegacyFabric/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_12_2-legacyfabric",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (Legacy Fabric 1.12.2)",
   "description": "Version-specific code for 1.12.2 under Legacy Fabric.",

--- a/1.12.2_Ornithe/src/main/resources/fabric.mod.json
+++ b/1.12.2_Ornithe/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_12_2-ornithe",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (Ornithe 1.12.2)",
   "description": "Version-specific code for 1.12.2 under Ornithe.",

--- a/1.13.2_LegacyFabric/src/main/resources/fabric.mod.json
+++ b/1.13.2_LegacyFabric/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_13_2-legacyfabric",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (Legacy Fabric 1.13.2)",
   "description": "Version-specific code for 1.13.2 under Legacy Fabric.",

--- a/1.13.2_Ornithe/src/main/resources/fabric.mod.json
+++ b/1.13.2_Ornithe/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_13_2-ornithe",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (Ornithe 1.13.2)",
   "description": "Version-specific code for 1.13.2 under Ornithe.",

--- a/1.14.4/src/main/resources/fabric.mod.json
+++ b/1.14.4/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_14_4",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.14.4)",
   "description": "Version-specific code for 1.14.4.",

--- a/1.14.4_Ornithe/src/main/resources/fabric.mod.json
+++ b/1.14.4_Ornithe/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_14_4-ornithe",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (Ornithe 1.14.4)",
   "description": "Version-specific code for 1.14.4 under Ornithe.",

--- a/1.15.2/src/main/resources/fabric.mod.json
+++ b/1.15.2/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_15_2",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.15.2)",
   "description": "Version-specific code for 1.15.2.",

--- a/1.16.5/src/main/resources/fabric.mod.json
+++ b/1.16.5/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_16_5",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.16.5)",
   "description": "Version-specific code for 1.16.5.",

--- a/1.17.1/src/main/resources/fabric.mod.json
+++ b/1.17.1/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_17_1",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.17.1)",
   "description": "Version specific code for 1.17.1.",

--- a/1.18.2/src/main/resources/fabric.mod.json
+++ b/1.18.2/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_18_2",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.18.2)",
   "description": "Version specific code for 1.18.2.",

--- a/1.19.2/src/main/resources/fabric.mod.json
+++ b/1.19.2/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_19_2",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.19.2)",
   "description": "Version specific code for 1.19.2.",

--- a/1.19.4/src/main/resources/fabric.mod.json
+++ b/1.19.4/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_19_4",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.19.4)",
   "description": "Version specific code for 1.19.4.",

--- a/1.19/src/main/resources/fabric.mod.json
+++ b/1.19/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_19",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.19)",
   "description": "Version specific code for 1.19.",

--- a/1.20.1/src/main/resources/fabric.mod.json
+++ b/1.20.1/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_20_1",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.20.1)",
   "description": "Version specific code for 1.20.1.",

--- a/1.20.2/src/main/resources/fabric.mod.json
+++ b/1.20.2/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_20_2",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.20.2)",
   "description": "Version-specific code for 1.20.2.",

--- a/1.20.4/src/main/resources/fabric.mod.json
+++ b/1.20.4/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_20_4",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.20.4)",
   "description": "Version-specific code for 1.20.4.",

--- a/1.20.6/src/main/resources/fabric.mod.json
+++ b/1.20.6/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_20_6",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.20.6)",
   "description": "Version-specific code for 1.20.6.",

--- a/1.21.1/src/main/resources/fabric.mod.json
+++ b/1.21.1/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_21_1",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.21.1)",
   "description": "Version-specific code for 1.21.1.",

--- a/1.21.3/src/main/resources/fabric.mod.json
+++ b/1.21.3/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_21_3",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.21.3)",
   "description": "Version-specific code for 1.21.3.",

--- a/1.21.4/src/main/resources/fabric.mod.json
+++ b/1.21.4/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_21_4",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.21.4)",
   "description": "Version-specific code for 1.21.4.",

--- a/1.21.5/src/main/resources/fabric.mod.json
+++ b/1.21.5/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "librarian-resources-1_21_5",
+  "id": "librarian-resources",
   "version": "${version}",
   "name": "Librarian Hooks (1.21.5)",
   "description": "Version-specific code for 1.21.5.",


### PR DESCRIPTION
I've worked on many multi-version mods over the years and a common annoyance I've found is that if your client fails to start due to unrelated issues with other mods not having dependencies or being outright incompatible with one another, the actual window containing the details would just be filled with "Mod 'ABC' (abc) 3.0 requires version X, but only wrong version is present: Y" messages, as shown below:

![https://media-new.videogamesm12.me/GqxeF7Lh4kv0.png](https://media-new.videogamesm12.me/GqxeF7Lh4kv0.png)

This is an annoying consequence of how the Fabric Loader handles multi-version mods like this. Under normal circumstances it would simply ignore the embedded mods that didn't meet any requirements and would thus have no effect on runtime. However, that is all thrown out the window when an instance fails to start because a dependency for some unrelated mod isn't installed because now suddenly the loader is looking for those irrelevant entries it discarded in hopes of finding any other problems. I used to just tolerate it since during runtime it has absolutely no effect and is only a cosmetic issue, but since I want to polish this mod now I want to ensure it looks as good as it works.

I've figured out a way to _reduce_ the amount of entries, but due to some very interesting shenanigans with how the Fabric Loader works, I can't actually remove all irrelevant entries. It feels like the loader picks instances of `librarian-resources` at random and just hopes it gets the right one. This is likely due to how the mod prioritizes entries, since it sorts by both ID and mod version, so when they're identical things get very funky. These are on the same instance and were taken just seconds apart from eachother:

![https://media-new.videogamesm12.me/K1ZT1DkXcqlm.png](https://media-new.videogamesm12.me/K1ZT1DkXcqlm.png)
![https://media-new.videogamesm12.me/uwychRxQvHMo.png](https://media-new.videogamesm12.me/uwychRxQvHMo.png)

This issue is why I didn't just push this directly to master, as this could cause some unnecessary confusion on what versions Librarian supports. I'm looking into solutions but I'm concerned that this is probably something more to do with making an issue on the Fabric Loader's issue tracker and not something I could easily fix on my own.