### PR TITLE
Adds /lb as an alias of /librarian

### DIFF
--- a/1.14.4/src/main/java/me/videogamesm12/librarian/v1_14_4/addon/CottonClientCommandsAddon.java
+++ b/1.14.4/src/main/java/me/videogamesm12/librarian/v1_14_4/addon/CottonClientCommandsAddon.java
@@ -20,6 +20,7 @@ package me.videogamesm12.librarian.v1_14_4.addon;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import io.github.cottonmc.clientcommands.ArgumentBuilders;
 import io.github.cottonmc.clientcommands.ClientCommandPlugin;
 import io.github.cottonmc.clientcommands.CottonClientCommandSource;
@@ -47,7 +48,7 @@ public class CottonClientCommandsAddon implements ClientCommandPlugin
 	@Override
 	public void registerCommands(CommandDispatcher<CottonClientCommandSource> commandDispatcher)
 	{
-		commandDispatcher.register(
+		final LiteralCommandNode<CottonClientCommandSource> mainCommand = commandDispatcher.register(
 				ArgumentBuilders.literal("librarian")
 						.then(ArgumentBuilders.literal("goto")
 								.then(ArgumentBuilders.argument("page", LongArgumentType.longArg())
@@ -286,6 +287,8 @@ public class CottonClientCommandsAddon implements ClientCommandPlugin
 
 															return 1;
 														}))))));
+
+		commandDispatcher.register(ArgumentBuilders.literal("lb").redirect(mainCommand));
 	}
 
 	private void feedback(CottonClientCommandSource source, Component message)

--- a/1.15.2/src/main/java/me/videogamesm12/librarian/v1_15_2/addon/CottonClientCommandsAddon.java
+++ b/1.15.2/src/main/java/me/videogamesm12/librarian/v1_15_2/addon/CottonClientCommandsAddon.java
@@ -20,6 +20,7 @@ package me.videogamesm12.librarian.v1_15_2.addon;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import io.github.cottonmc.clientcommands.ArgumentBuilders;
 import io.github.cottonmc.clientcommands.ClientCommandPlugin;
 import io.github.cottonmc.clientcommands.CottonClientCommandSource;
@@ -46,7 +47,7 @@ public class CottonClientCommandsAddon implements ClientCommandPlugin
 	@Override
 	public void registerCommands(CommandDispatcher<CottonClientCommandSource> commandDispatcher)
 	{
-		commandDispatcher.register(
+		final LiteralCommandNode<CottonClientCommandSource> mainCommand = commandDispatcher.register(
 				ArgumentBuilders.literal("librarian")
 						.then(ArgumentBuilders.literal("goto")
 								.then(ArgumentBuilders.argument("page", LongArgumentType.longArg())
@@ -286,6 +287,8 @@ public class CottonClientCommandsAddon implements ClientCommandPlugin
 
 															return 1;
 														}))))));
+
+		commandDispatcher.register(ArgumentBuilders.literal("lb").redirect(mainCommand));
 	}
 
 	private void feedback(CottonClientCommandSource source, Component message)

--- a/1.16.5/src/main/java/me/videogamesm12/librarian/v1_16_5/addon/FabricClientCommandAPIAddon.java
+++ b/1.16.5/src/main/java/me/videogamesm12/librarian/v1_16_5/addon/FabricClientCommandAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_16_5.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
 import me.videogamesm12.librarian.api.IMechanicFactory;
@@ -48,7 +49,7 @@ public class FabricClientCommandAPIAddon implements IAddon
 	@Override
 	public void init()
 	{
-		ClientCommandManager.DISPATCHER.register(
+		final LiteralCommandNode<FabricClientCommandSource> mainCommand = ClientCommandManager.DISPATCHER.register(
 				ClientCommandManager.literal("librarian")
 						.then(ClientCommandManager.literal("goto")
 								.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
@@ -289,6 +290,8 @@ public class FabricClientCommandAPIAddon implements IAddon
 
 															return 0;
 														}))))));
+
+		ClientCommandManager.DISPATCHER.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 	}
 
 	private void feedback(FabricClientCommandSource source, Component message)

--- a/1.17.1/src/main/java/me/videogamesm12/librarian/v1_17_1/addon/FabricAPIAddon.java
+++ b/1.17.1/src/main/java/me/videogamesm12/librarian/v1_17_1/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_17_1.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -92,7 +93,7 @@ public class FabricAPIAddon implements IAddon
 			}
 		});
 
-		ClientCommandManager.DISPATCHER.register(
+		final LiteralCommandNode<FabricClientCommandSource> mainCommand = ClientCommandManager.DISPATCHER.register(
 				ClientCommandManager.literal("librarian")
 						.then(ClientCommandManager.literal("goto")
 								.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
@@ -315,6 +316,8 @@ public class FabricAPIAddon implements IAddon
 
 															return 0;
 														}))))));
+
+		ClientCommandManager.DISPATCHER.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 	}
 
 	private void feedback(FabricClientCommandSource source, Component message)

--- a/1.18.2/src/main/java/me/videogamesm12/librarian/v1_18_2/addon/FabricAPIAddon.java
+++ b/1.18.2/src/main/java/me/videogamesm12/librarian/v1_18_2/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_18_2.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -92,7 +93,7 @@ public class FabricAPIAddon implements IAddon
 			}
 		});
 
-		ClientCommandManager.DISPATCHER.register(
+		final LiteralCommandNode<FabricClientCommandSource> mainCommand = ClientCommandManager.DISPATCHER.register(
 				ClientCommandManager.literal("librarian")
 						.then(ClientCommandManager.literal("goto")
 								.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
@@ -312,6 +313,8 @@ public class FabricAPIAddon implements IAddon
 
 															return 0;
 														}))))));
+
+		ClientCommandManager.DISPATCHER.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 	}
 
 	private void feedback(FabricClientCommandSource source, Component message)

--- a/1.19.2/src/main/java/me/videogamesm12/librarian/v1_19_2/addon/FabricAPIAddon.java
+++ b/1.19.2/src/main/java/me/videogamesm12/librarian/v1_19_2/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_19_2.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.19.4/src/main/java/me/videogamesm12/librarian/v1_19_4/addon/FabricAPIAddon.java
+++ b/1.19.4/src/main/java/me/videogamesm12/librarian/v1_19_4/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_19_4.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.19/src/main/java/me/videogamesm12/librarian/v1_19/addon/FabricAPIAddon.java
+++ b/1.19/src/main/java/me/videogamesm12/librarian/v1_19/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_19.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.20.1/src/main/java/me/videogamesm12/librarian/v1_20_1/addon/FabricAPIAddon.java
+++ b/1.20.1/src/main/java/me/videogamesm12/librarian/v1_20_1/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_20_1.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.20.2/src/main/java/me/videogamesm12/librarian/v1_20_2/addon/FabricAPIAddon.java
+++ b/1.20.2/src/main/java/me/videogamesm12/librarian/v1_20_2/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_20_2.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.20.4/src/main/java/me/videogamesm12/librarian/v1_20_4/addon/FabricAPIAddon.java
+++ b/1.20.4/src/main/java/me/videogamesm12/librarian/v1_20_4/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_20_4.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.20.6/src/main/java/me/videogamesm12/librarian/v1_20_6/addon/FabricAPIAddon.java
+++ b/1.20.6/src/main/java/me/videogamesm12/librarian/v1_20_6/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_20_6.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.21.1/src/main/java/me/videogamesm12/librarian/v1_21_1/addon/FabricAPIAddon.java
+++ b/1.21.1/src/main/java/me/videogamesm12/librarian/v1_21_1/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_21_1.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.21.3/src/main/java/me/videogamesm12/librarian/v1_21_3/addon/FabricAPIAddon.java
+++ b/1.21.3/src/main/java/me/videogamesm12/librarian/v1_21_3/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_21_3.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.21.4/src/main/java/me/videogamesm12/librarian/v1_21_4/addon/FabricAPIAddon.java
+++ b/1.21.4/src/main/java/me/videogamesm12/librarian/v1_21_4/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_21_4.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 

--- a/1.21.5/src/main/java/me/videogamesm12/librarian/v1_21_5/addon/FabricAPIAddon.java
+++ b/1.21.5/src/main/java/me/videogamesm12/librarian/v1_21_5/addon/FabricAPIAddon.java
@@ -19,6 +19,7 @@ package me.videogamesm12.librarian.v1_21_5.addon;
 
 import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
 import lombok.Getter;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
@@ -95,7 +96,7 @@ public class FabricAPIAddon implements IAddon
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, access) ->
 		{
-			dispatcher.register(ClientCommandManager.literal("librarian")
+			final LiteralCommandNode<FabricClientCommandSource> mainCommand = dispatcher.register(ClientCommandManager.literal("librarian")
 					.then(ClientCommandManager.literal("goto")
 							.then(ClientCommandManager.argument("page", LongArgumentType.longArg())
 									.executes(context ->
@@ -317,6 +318,8 @@ public class FabricAPIAddon implements IAddon
 
 														return 0;
 													}))))));
+
+			dispatcher.register(ClientCommandManager.literal("lb").redirect(mainCommand));
 		});
 	}
 


### PR DESCRIPTION
**NOTE: Due to how late this was implemented in the development cycle, this feature may not be added to the mainstream 3.0 release, but if that doesn't happen it will be added as part of the release of version 3.1.**

This PR makes a change to the client command system to add an extra alias to /librarian in the form of /lb. The reason this wasn't pushed to the main branch was because the idea needs to be thoroughly tested to make sure it does not get in the way of other mods or even server-side plugins.