### PR TITLE
Drag-and-drop feature

### DIFF
--- a/1.21.4/src/main/java/me/videogamesm12/librarian/v1_21_4/mixin/HandledScreenAccessor.java
+++ b/1.21.4/src/main/java/me/videogamesm12/librarian/v1_21_4/mixin/HandledScreenAccessor.java
@@ -18,6 +18,7 @@
 package me.videogamesm12.librarian.v1_21_4.mixin;
 
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.screen.slot.Slot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -29,4 +30,7 @@ public interface HandledScreenAccessor
 
 	@Accessor
 	int getY();
+
+	@Accessor
+	Slot getFocusedSlot();
 }

--- a/1.21.4/src/main/java/me/videogamesm12/librarian/v1_21_4/mixin/PlayerInventoryAccessor.java
+++ b/1.21.4/src/main/java/me/videogamesm12/librarian/v1_21_4/mixin/PlayerInventoryAccessor.java
@@ -1,0 +1,13 @@
+package me.videogamesm12.librarian.v1_21_4.mixin;
+
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(PlayerInventory.class)
+public interface PlayerInventoryAccessor
+{
+	@Invoker
+	int invokeAddStack(int slot, ItemStack stack);
+}

--- a/1.21.4/src/main/resources/librarian.v1_21_4.mixins.json
+++ b/1.21.4/src/main/resources/librarian.v1_21_4.mixins.json
@@ -12,5 +12,8 @@
     "HotbarStorageMixin",
     "MinecraftClientMixin",
     "ScreenAccessor"
+  ],
+  "mixins": [
+    "PlayerInventoryAccessor"
   ]
 }


### PR DESCRIPTION
A commonly requested feature for Librarian is the ability to drag and drop items into saved hotbar pages. This feature would make it far easier to save items since then you could just put it in yourself.

I don't want to just implement the idea, I want to evolve it. So, in addition to being able to drag and drop items into the creative inventory, I'm also going to experiment with the ability to shift click items into the page by having it detect the nearest empty slot and adding it to there. Of course, accidental overwrite prevention is also in place. To delete items, I've decided to make it so that you have to hit the delete key instead of the middle click.

At the moment, I have only implemented this in 1.21.4. Once the core idea has been well refined, it will be ported to the rest of the version set.