### PR TITLE
Allow hotbar pages to be directly modified (drag & drop, shift-clicking)

### DIFF
--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/addon/FabricAPIAddon.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/addon/FabricAPIAddon.java
@@ -62,6 +62,7 @@ public class FabricAPIAddon implements IAddon
 	private KeyBinding nextKey = null;
 	private KeyBinding previousKey = null;
 	private KeyBinding backupKey = null;
+	private KeyBinding deleteKey = null;
 
 	@Override
 	public void init()
@@ -81,6 +82,11 @@ public class FabricAPIAddon implements IAddon
 				InputUtil.Type.KEYSYM,
 				GLFW.GLFW_KEY_B,
 				actionsCategory));
+		deleteKey = KeyBindingHelper.registerKeyBinding(new KeyBinding("librarian.key.delete_item",
+				InputUtil.Type.KEYSYM,
+				GLFW.GLFW_KEY_DELETE,
+				actionsCategory));
+
 
 		ClientTickEvents.END_CLIENT_TICK.register(client ->
 		{

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenAccessor.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenAccessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Video
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.videogamesm12.librarian.v1_21_11.mixin;
+
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(CreativeInventoryScreen.class)
+public interface CreativeInventoryScreenAccessor
+{
+	@Accessor
+	void setScrollPosition(float scrollPosition);
+}

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
@@ -640,8 +640,6 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 				&& isCreativeInventorySlot(slot)
 				&& (actionType == SlotActionType.PICKUP || actionType == SlotActionType.SWAP))
 		{
-			Librarian.getLogger().warn("Detected click relevant to us!");
-
 			final IWrappedHotbarStorageEntry<ItemStack> wrappedStorageEntry = wrapped.librarian$get(row);
 			final ItemStack original = wrappedStorageEntry.librarian$getItem(column).copy();
 			float scroll = scrollPosition;

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
@@ -82,6 +82,8 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 
 	@Unique
 	private static ItemGroup lastGroup = null;
+	@Unique
+	private static boolean readyToSave = true;
 
 	@Shadow
 	private TextFieldWidget searchBox;
@@ -693,6 +695,12 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 			// Prevent items from being lost accidentally
 			ci.cancel();
 
+			// Avoid saving until we are flagged as ready to do so
+			if (!readyToSave)
+			{
+				return;
+			}
+
 			// Scan for empty slots
 			scan:
 			for (row = 0; row < wrapped.librarian$getRowCount(); row++)
@@ -716,8 +724,12 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 								entry,
 								Collections.singletonList(entry.librarian$getItem(column)),
 								() -> {
+									// Prevent accidentally
+									readyToSave = false;
 									entry.librarian$setItem(fuckOffIntellij, slot.getStack().copy());
 									page.save();
+
+									readyToSave = true;
 
 									// Remove the item from their inventory
 									Objects.requireNonNull(client.player).getInventory().setStack(slot.getIndex(), ItemStack.EMPTY);

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
@@ -21,10 +21,7 @@ import com.google.common.eventbus.Subscribe;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import me.videogamesm12.librarian.Librarian;
-import me.videogamesm12.librarian.api.HotbarPageMetadata;
-import me.videogamesm12.librarian.api.IMechanicFactory;
-import me.videogamesm12.librarian.api.IWrappedHotbarStorage;
-import me.videogamesm12.librarian.api.LoadStatus;
+import me.videogamesm12.librarian.api.*;
 import me.videogamesm12.librarian.api.event.AsyncPageLoadEvent;
 import me.videogamesm12.librarian.api.event.CacheClearEvent;
 import me.videogamesm12.librarian.api.event.NavigationEvent;
@@ -47,16 +44,20 @@ import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.client.input.CharInput;
 import net.minecraft.client.input.KeyInput;
 import net.minecraft.client.option.HotbarStorage;
+import net.minecraft.client.option.HotbarStorageEntry;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.registry.Registries;
 import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -69,9 +70,10 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 @Mixin(CreativeInventoryScreen.class)
 public abstract class CreativeInventoryScreenMixin extends Screen
@@ -91,6 +93,13 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 
 	@Shadow
 	private @Nullable List<Slot> slots;
+
+	@Shadow
+	protected abstract boolean isCreativeInventorySlot(@Nullable Slot slot);
+
+	@Shadow
+	@Final
+	private boolean operatorTabEnabled;
 	@Unique
 	private IMechanicFactory mechanic;
 
@@ -522,93 +531,13 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 
 		if (save)
 		{
-			boolean backgroundSaving = librarian.getConfig().optimizations().backgroundSaving();
-
-			Runnable operation = () ->
-			{
-				final List<String> issues = new ArrayList<>();
-
-				downgradeCheck:
-				{
-					if (wrappedStorage.librarian$dataVersion() > SharedConstants.getGameVersion().dataVersion().id())
-					{
-						issues.add("downgrade");
-						break downgradeCheck;
-					}
-				}
-
-				overwriteCheck:
-				{
-					final List<ItemStack> storageEntry = storage.getSavedHotbar(index).deserialize(Objects.requireNonNull(client.world)
-							.getRegistryManager());
-
-					if (storageEntry.isEmpty())
-					{
-						break overwriteCheck;
-					}
-
-					for (int i = 0; i < PlayerInventory.getHotbarSize(); i++)
-					{
-						ItemStack inventoryStack = Objects.requireNonNull(client.player).getInventory().getStack(i);
-						ItemStack hotbarEntry = storageEntry.get(i);
-
-						if (!hotbarEntry.isEmpty() && !ItemStack.areItemsAndComponentsEqual(inventoryStack, hotbarEntry))
-						{
-							issues.add("nonmatching");
-							break overwriteCheck;
-						}
-					}
-				}
-
-				if (!issues.isEmpty())
-				{
-					final MutableText title;
-					final MutableText description;
-
-					// Only one issue found, use more specific message for that
-					if (issues.size() == 1)
-					{
-						title = Text.translatable("librarian.messages.issues." + issues.getFirst() + ".title");
-						description = Text.translatable("librarian.messages.issues." + issues.getFirst() + ".description");
-					}
-					// Otherwise, use more brief versions instead
-					else
-					{
-						title = Text.translatable("librarian.messages.possible_loss_scenario_detected.title");
-						description = Text.translatable("librarian.messages.possible_loss_scenario_detected.description");
-						issues.forEach(issue -> description.append(Text.translatable("librarian.messages.issues." + issue + ".summary")).append("\n\n"));
-						description.append(Text.translatable("librarian.messages.possible_loss_scenario_detected.footer"));
-					}
-
-					// This is unbelievably bad for an optimization hack, but if I don't run setScreen() on the game
-					// 	thread, the entire game crashes. If I don't account for background saving in the nested block,
-					// 	then the game runs the "save" code on the game thread when it shouldn't, causing lagspikes
-					client.execute(() -> client.setScreen(new ConfirmScreen((value) ->
-					{
-						if (value)
-						{
-							if (backgroundSaving)
-								librarian.queue(() -> original.call(client, index, restore, save));
-							else
-								original.call(client, index, restore, save);
-						}
-						MinecraftClient.getInstance().setScreen(null);
-					}, title, description)));
-				}
-				else
-				{
-					original.call(client, index, restore, save);
-				}
-			};
-
-			if (backgroundSaving)
-			{
-				librarian.queue(operation);
-			}
-			else
-			{
-				operation.run();
-			}
+			checkBeforeOperation(storage,
+					wrappedStorage.librarian$get(index),
+					IntStream.range(0, PlayerInventory.getHotbarSize()).mapToObj(column ->
+							Objects.requireNonNull(client.player).getInventory().getStack(column)).toList(),
+					() -> original.call(client, index, restore, save),
+					(value) -> MinecraftClient.getInstance().setScreen(null),
+					-1337);
 		}
 		else
 		{
@@ -626,6 +555,146 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 		}
 
 		return stack;
+	}
+
+	@Inject(method = "onMouseClick", at = @At("HEAD"), cancellable = true)
+	public void directlyModifyHotbar(Slot slot, int slotId, int button, SlotActionType actionType, CallbackInfo ci)
+	{
+		if (!tabIsHotbar(getSelectedTab())
+				|| slot == null
+				|| Librarian.getInstance().getCurrentPage().librarian$getLoadStatus() != LoadStatus.LOADED)
+		{
+			return;
+		}
+
+		final CreativeInventoryScreen.CreativeScreenHandler handler = ((HandledScreenAccessor) this).getHandler();
+
+		// Determine row and column
+		int row = slot.getIndex() / 9 + (Math.round(4 * scrollPosition));
+		int column = slot.getIndex() % 9;
+
+		// Get the item stack in their cursor
+		final ItemStack cursor = handler.getCursorStack().copy();
+
+		// Get everything related to the current hotbar page
+		final HotbarStorage page = (HotbarStorage) Librarian.getInstance().getCurrentPage();
+		final IWrappedHotbarStorage wrapped = (IWrappedHotbarStorage) page;
+
+		// If the item in their cursor isn't air and the action they are trying to do is related to adding/swapping them...
+		if (cursor.getItem() != Items.AIR
+				&& isCreativeInventorySlot(slot)
+				&& (actionType == SlotActionType.PICKUP || actionType == SlotActionType.SWAP))
+		{
+			Librarian.getLogger().warn("Detected click relevant to us!");
+
+			final IWrappedHotbarStorageEntry<ItemStack> wrappedStorageEntry = wrapped.librarian$get(row);
+			final ItemStack original = wrappedStorageEntry.librarian$getItem(column).copy();
+			float scroll = scrollPosition;
+
+			final int fuckOffIntellij = column;
+
+			checkBeforeOperation(page,
+					wrappedStorageEntry,
+					Collections.singletonList(cursor.copy()),
+					() -> {
+						wrappedStorageEntry.librarian$setItem(fuckOffIntellij, cursor.copy());
+						page.save();
+
+						// If we weren't prompted, update the current screen
+						if (client.currentScreen instanceof CreativeInventoryScreen screen)
+						{
+							setSelectedTab(Registries.ITEM_GROUP.get(ItemGroups.HOTBAR));
+							handler.scrollItems(scroll);
+							scrollPosition = scroll;
+
+							if (!original.isEmpty())
+							{
+								((HandledScreenAccessor) screen).getHandler().setCursorStack(original);
+							}
+						}
+					},
+					(value) -> {
+						final CreativeInventoryScreen screen = new CreativeInventoryScreen(Objects.requireNonNull(client.player),
+								Objects.requireNonNull(client.getNetworkHandler()).getEnabledFeatures(),
+								operatorTabEnabled);
+
+						client.setScreen(screen);
+
+						((CreativeInventoryScreen.CreativeScreenHandler) ((HandledScreenAccessor) screen).getHandler()).scrollItems(scroll);
+						// What the hell do you mean "it'll throw a class cast exception"? No it won't?
+						((CreativeInventoryScreenAccessor) screen).setScrollPosition(scroll);
+						((HandledScreenAccessor) screen).getHandler().setCursorStack(value ? original : cursor);
+					},
+					column);
+
+			ci.cancel();
+		}
+		// If the item they're clicking isn't air, is in their inventory, and the user shift-clicked...
+		else if (slot.getStack().getItem() != Items.AIR
+				&& !isCreativeInventorySlot(slot)
+				&& actionType == SlotActionType.QUICK_MOVE)
+		{
+			// Basic idea for functionality: upon shift-clicking the item from your inventory, we look for a spot for
+			// 	empty space and if we find one, we use that. Otherwise, we simply do nothing.
+
+			// Prevent items from being lost accidentally
+			ci.cancel();
+
+			// Scan for empty slots
+			scan:
+			for (row = 0; row < wrapped.librarian$getRowCount(); row++)
+			{
+				final IWrappedHotbarStorageEntry<ItemStack> entry = wrapped.librarian$get(row);
+
+				for (column = 0; column < PlayerInventory.getHotbarSize(); column++)
+				{
+					// Found an empty slot!
+					if (entry.librarian$getItem(column).getItem() == Items.AIR)
+					{
+						// Store a hash of
+						final int screenCode = Objects.requireNonNull(client.currentScreen).hashCode();
+
+						float scroll = scrollPosition;
+						final int fuckOffIntellij = column;
+
+						// We're not concerned about accidentally overwriting a row since that isn't possible, but we
+						// 	are concerned about other checks like accidental downgrades.
+						checkBeforeOperation(page,
+								entry,
+								Collections.singletonList(entry.librarian$getItem(column)),
+								() -> {
+									entry.librarian$setItem(fuckOffIntellij, slot.getStack().copy());
+									page.save();
+
+									// Remove the item from their inventory
+									Objects.requireNonNull(client.player).getInventory().setStack(slot.getIndex(), ItemStack.EMPTY);
+									Objects.requireNonNull(client.interactionManager).clickCreativeStack(ItemStack.EMPTY, slotId);
+
+									if (client.currentScreen != null && client.currentScreen.hashCode() == screenCode)
+									{
+										setSelectedTab(Registries.ITEM_GROUP.get(ItemGroups.HOTBAR));
+										handler.scrollItems(scroll);
+										scrollPosition = scroll;
+									}
+								},
+								(value) -> {
+									final CreativeInventoryScreen screen = new CreativeInventoryScreen(Objects.requireNonNull(client.player),
+											Objects.requireNonNull(client.getNetworkHandler()).getEnabledFeatures(),
+											operatorTabEnabled);
+
+									client.setScreen(screen);
+
+									((CreativeInventoryScreen.CreativeScreenHandler) ((HandledScreenAccessor) screen).getHandler()).scrollItems(scroll);
+									// It is literally impossible for it to throw that exception, shut up Intellij
+									((CreativeInventoryScreenAccessor) screen).setScrollPosition(scroll);
+								},
+								column);
+
+						break scan;
+					}
+				}
+			}
+		}
 	}
 
 	@Subscribe
@@ -666,6 +735,127 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 		if (tabIsHotbar(getSelectedTab()) && event.getPage().librarian$getPageNumber().equals(librarian.getCurrentPageNumber()))
 		{
 			MinecraftClient.getInstance().execute(() -> setSelectedTab(Registries.ITEM_GROUP.get(ItemGroups.HOTBAR)));
+		}
+	}
+
+	@Unique
+	private static void checkBeforeOperation(HotbarStorage storage, IWrappedHotbarStorageEntry<ItemStack> row,
+											 List<ItemStack> items, Runnable ifYes, Consumer<Boolean> cleanup, int columnIfSingular)
+	{
+		final MinecraftClient client = MinecraftClient.getInstance();
+		final IWrappedHotbarStorage wrapped = (IWrappedHotbarStorage) storage;
+		final boolean backgroundSaving = librarian.getConfig().optimizations().backgroundSaving();
+
+		Runnable scanner = () ->
+		{
+			final List<String> issues = new ArrayList<>();
+
+			downgradeCheck:
+			{
+				if (wrapped.librarian$dataVersion() > SharedConstants.getGameVersion().dataVersion().id())
+				{
+					issues.add("downgrade");
+					break downgradeCheck;
+				}
+			}
+
+			overwriteCheck:
+			{
+				final List<ItemStack> storageEntry = ((HotbarStorageEntry) row).deserialize(Objects.requireNonNull(client.world)
+						.getRegistryManager());
+
+				if (storageEntry.isEmpty())
+				{
+					break overwriteCheck;
+				}
+
+				if (items.size() == 1)
+				{
+					final ItemStack inventoryStack = items.getFirst();
+					final ItemStack hotbarEntry = storageEntry.get(columnIfSingular);
+
+					if (!hotbarEntry.isEmpty() && !ItemStack.areItemsAndComponentsEqual(inventoryStack, hotbarEntry))
+					{
+						issues.add("nonmatching");
+						break overwriteCheck;
+					}
+				}
+				else
+				{
+					for (int i = 0; i < PlayerInventory.getHotbarSize(); i++)
+					{
+						ItemStack inventoryStack = items.get(i);
+						ItemStack hotbarEntry = storageEntry.get(i);
+
+						if (!hotbarEntry.isEmpty() && !ItemStack.areItemsAndComponentsEqual(inventoryStack, hotbarEntry))
+						{
+							issues.add("nonmatching");
+							break overwriteCheck;
+						}
+					}
+				}
+			}
+
+			if (!issues.isEmpty())
+			{
+				final MutableText title;
+				final MutableText description;
+
+				// Only one issue found, use more specific message for that
+				if (issues.size() == 1)
+				{
+					title = Text.translatable("librarian.messages.issues." + issues.getFirst() + ".title");
+					description = Text.translatable("librarian.messages.issues." + issues.getFirst() + ".description");
+				}
+				// Otherwise, use more brief versions instead
+				else
+				{
+					title = Text.translatable("librarian.messages.possible_loss_scenario_detected.title");
+					description = Text.translatable("librarian.messages.possible_loss_scenario_detected.description");
+					issues.forEach(issue -> description.append(Text.translatable("librarian.messages.issues." + issue + ".summary")).append("\n\n"));
+					description.append(Text.translatable("librarian.messages.possible_loss_scenario_detected.footer"));
+				}
+
+				// This is unbelievably bad for an optimization hack, but if I don't run setScreen() on the game
+				// 	thread, the entire game crashes. If I don't account for background saving in the nested block,
+				// 	then the game runs the "save" code on the game thread when it shouldn't, causing lagspikes
+				client.execute(() -> client.setScreen(new ConfirmScreen((value) ->
+				{
+					if (value)
+					{
+						if (backgroundSaving)
+						{
+							Librarian.getInstance().queue(ifYes);
+						}
+						else
+						{
+							ifYes.run();
+						}
+					}
+
+					cleanup.accept(value);
+				}, title, description)));
+			}
+			else
+			{
+				if (backgroundSaving)
+				{
+					Librarian.getInstance().queue(ifYes);
+				}
+				else
+				{
+					ifYes.run();
+				}
+			}
+		};
+
+		if (backgroundSaving)
+		{
+			Librarian.getInstance().queue(scanner);
+		}
+		else
+		{
+			scanner.run();
 		}
 	}
 

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeInventoryScreenMixin.java
@@ -22,10 +22,7 @@ import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.*;
-import me.videogamesm12.librarian.api.event.AsyncPageLoadEvent;
-import me.videogamesm12.librarian.api.event.CacheClearEvent;
-import me.videogamesm12.librarian.api.event.NavigationEvent;
-import me.videogamesm12.librarian.api.event.ReloadPageEvent;
+import me.videogamesm12.librarian.api.event.*;
 import me.videogamesm12.librarian.util.ComponentProcessor;
 import me.videogamesm12.librarian.v1_21_11.addon.FabricAPIAddon;
 import net.fabricmc.fabric.impl.client.itemgroup.FabricCreativeGuiComponents;
@@ -392,7 +389,7 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 	@Inject(method = "keyPressed", at = @At(value = "INVOKE",
 			target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;keyPressed(Lnet/minecraft/client/input/KeyInput;)Z",
 			shift = At.Shift.BEFORE), cancellable = true)
-	public void handleNavigationKeys(KeyInput input, CallbackInfoReturnable<Boolean> cir)
+	public void handleActionKeys(KeyInput input, CallbackInfoReturnable<Boolean> cir)
 	{
 		// Librarian-specific keybinds
 		if (tabIsHotbar(getSelectedTab()))
@@ -414,6 +411,62 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 			else if (fabric.getBackupKey().matchesKey(input))
 			{
 				librarian.queue(() -> librarian.getCurrentPage().librarian$backup());
+				cir.setReturnValue(true);
+				return;
+			}
+			else if (fabric.getDeleteKey().matchesKey(input))
+			{
+				final Slot focusedSlot = ((HandledScreenAccessor) this).getFocusedSlot();
+				if (focusedSlot == null
+						|| !isCreativeInventorySlot(focusedSlot)
+						|| focusedSlot.getStack().isEmpty()
+						|| librarian.getCurrentPage().librarian$getLoadStatus() != LoadStatus.LOADED)
+				{
+					return;
+				}
+
+				final CreativeInventoryScreen.CreativeScreenHandler handler = ((HandledScreenAccessor) this).getHandler();
+
+				final int row = (((CreativeScreenHandlerMixin) handler).invokeGetRow(scrollPosition) + (focusedSlot.getIndex() / 9));
+				final int column = focusedSlot.getIndex() % 9;
+
+				final IWrappedHotbarStorage wrappedStorage = librarian.getCurrentPage();
+				final HotbarStorage storage = (HotbarStorage) wrappedStorage;
+				final IWrappedHotbarStorageEntry<ItemStack> entry = wrappedStorage.librarian$get(row);
+
+
+				float scroll = scrollPosition;
+
+				checkBeforeOperation(storage,
+						entry,
+						Collections.singletonList(ItemStack.EMPTY),
+						() -> {
+							entry.librarian$setItem(column, ItemStack.EMPTY);
+							storage.save();
+
+							// If we weren't prompted, update the current screen
+							if (client.currentScreen instanceof CreativeInventoryScreen)
+							{
+								setSelectedTab(Registries.ITEM_GROUP.get(ItemGroups.HOTBAR));
+								handler.scrollItems(scroll);
+								scrollPosition = scroll;
+							}
+						},
+						(value) -> {
+							final CreativeInventoryScreen screen = new CreativeInventoryScreen(Objects.requireNonNull(client.player),
+									Objects.requireNonNull(client.getNetworkHandler()).getEnabledFeatures(),
+									operatorTabEnabled);
+
+							client.setScreen(screen);
+
+							((CreativeInventoryScreen.CreativeScreenHandler) ((HandledScreenAccessor) screen).getHandler()).scrollItems(scroll);
+							// https://www.youtube.com/watch?v=oiZ3VFCIUy0
+							((CreativeInventoryScreenAccessor) screen).setScrollPosition(scroll);
+						},
+						column,
+						"nonmatching");
+
+
 				cir.setReturnValue(true);
 				return;
 			}
@@ -569,16 +622,16 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 
 		final CreativeInventoryScreen.CreativeScreenHandler handler = ((HandledScreenAccessor) this).getHandler();
 
+		// Get everything related to the current hotbar page
+		final HotbarStorage page = (HotbarStorage) Librarian.getInstance().getCurrentPage();
+		final IWrappedHotbarStorage wrapped = (IWrappedHotbarStorage) page;
+
 		// Determine row and column
-		int row = slot.getIndex() / 9 + (Math.round(4 * scrollPosition));
+		int row = (((CreativeScreenHandlerMixin) handler).invokeGetRow(scrollPosition) + (slot.getIndex() / 9));
 		int column = slot.getIndex() % 9;
 
 		// Get the item stack in their cursor
 		final ItemStack cursor = handler.getCursorStack().copy();
-
-		// Get everything related to the current hotbar page
-		final HotbarStorage page = (HotbarStorage) Librarian.getInstance().getCurrentPage();
-		final IWrappedHotbarStorage wrapped = (IWrappedHotbarStorage) page;
 
 		// If the item in their cursor isn't air and the action they are trying to do is related to adding/swapping them...
 		if (cursor.getItem() != Items.AIR
@@ -651,7 +704,7 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 					// Found an empty slot!
 					if (entry.librarian$getItem(column).getItem() == Items.AIR)
 					{
-						// Store a hash of
+						// Store a hash of the menu so we can determine if we need to update it later
 						final int screenCode = Objects.requireNonNull(client.currentScreen).hashCode();
 
 						float scroll = scrollPosition;
@@ -740,11 +793,13 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 
 	@Unique
 	private static void checkBeforeOperation(HotbarStorage storage, IWrappedHotbarStorageEntry<ItemStack> row,
-											 List<ItemStack> items, Runnable ifYes, Consumer<Boolean> cleanup, int columnIfSingular)
+											 List<ItemStack> items, Runnable ifYes, Consumer<Boolean> cleanup,
+											 int columnIfSingular, String... ignored)
 	{
 		final MinecraftClient client = MinecraftClient.getInstance();
 		final IWrappedHotbarStorage wrapped = (IWrappedHotbarStorage) storage;
 		final boolean backgroundSaving = librarian.getConfig().optimizations().backgroundSaving();
+		final List<String> ignoredIssues = Arrays.stream(ignored).toList();
 
 		Runnable scanner = () ->
 		{
@@ -752,6 +807,11 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 
 			downgradeCheck:
 			{
+				if (ignoredIssues.contains("downgrade"))
+				{
+					break downgradeCheck;
+				}
+
 				if (wrapped.librarian$dataVersion() > SharedConstants.getGameVersion().dataVersion().id())
 				{
 					issues.add("downgrade");
@@ -761,6 +821,11 @@ public abstract class CreativeInventoryScreenMixin extends Screen
 
 			overwriteCheck:
 			{
+				if (ignoredIssues.contains("nonmatching"))
+				{
+					break overwriteCheck;
+				}
+
 				final List<ItemStack> storageEntry = ((HotbarStorageEntry) row).deserialize(Objects.requireNonNull(client.world)
 						.getRegistryManager());
 

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeScreenHandlerMixin.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/CreativeScreenHandlerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Video
+ * Copyright (C) 2026 Video
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,24 +17,16 @@
 
 package me.videogamesm12.librarian.v1_21_11.mixin;
 
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.screen.ScreenHandler;
-import net.minecraft.screen.slot.Slot;
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
-@Mixin(HandledScreen.class)
-public interface HandledScreenAccessor
+@Mixin(CreativeInventoryScreen.CreativeScreenHandler.class)
+public interface CreativeScreenHandlerMixin
 {
-	@Accessor(value = "x")
-	int getX();
+	@Invoker(value = "getRow")
+	int invokeGetRow(float f);
 
-	@Accessor(value = "y")
-	int getY();
-
-	@Accessor(value = "handler")
-	<T extends ScreenHandler> T getHandler();
-
-	@Accessor(value = "focusedSlot")
-	Slot getFocusedSlot();
+	@Invoker(value = "getOverflowRows")
+	int invokeGetOverflowRows();
 }

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/HotbarStorageEntryMixin.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/HotbarStorageEntryMixin.java
@@ -20,14 +20,19 @@ package me.videogamesm12.librarian.v1_21_11.mixin;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.DynamicOps;
 import me.videogamesm12.librarian.Librarian;
+import me.videogamesm12.librarian.api.IWrappedHotbarStorageEntry;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.HotbarStorageEntry;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtElement;
 import net.minecraft.registry.BuiltinRegistries;
 import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.RegistryOps;
 import net.minecraft.registry.RegistryWrapper;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -35,12 +40,12 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+
+import static org.apache.logging.log4j.ThreadContext.EMPTY_STACK;
 
 @Mixin(HotbarStorageEntry.class)
-public abstract class HotbarStorageEntryMixin
+public abstract class HotbarStorageEntryMixin implements IWrappedHotbarStorageEntry<ItemStack>
 {
 	@Unique
 	private static final RegistryWrapper.WrapperLookup WRAPPER_LOOKUP = BuiltinRegistries.createWrapperLookup();
@@ -48,6 +53,14 @@ public abstract class HotbarStorageEntryMixin
 	@Shadow
 	public abstract List<ItemStack> deserialize(RegistryWrapper.WrapperLookup par1);
 
+	@Shadow
+	@Final
+	private static DynamicOps<NbtElement> NBT_OPS;
+	@Shadow
+	private List<Dynamic<?>> stacks;
+	@Shadow
+	@Final
+	private static Dynamic<?> EMPTY_STACK;
 	@Unique
 	private final ItemStack[] cache =  new ItemStack[9];
 
@@ -98,6 +111,33 @@ public abstract class HotbarStorageEntryMixin
 		}
 
 		return original.call(registries);
+	}
+
+	@Override
+	public void librarian$setItem(int column, ItemStack value)
+	{
+		// Since we have the item already processed, we'll just set it in our cache
+		cache[column] = value;
+
+		// Converts the item to a Dynamic
+		final RegistryWrapper.WrapperLookup lookup = MinecraftClient.getInstance().world != null ?
+				MinecraftClient.getInstance().world.getRegistryManager() : WRAPPER_LOOKUP;
+		final RegistryOps<NbtElement> converter = lookup.getOps(NBT_OPS);
+		final Optional<Dynamic<?>> converted = ItemStack.OPTIONAL_CODEC.encodeStart(converter, value)
+				.resultOrPartial(error -> Librarian.getLogger().warn("Could not encode hotbar item: {}", error))
+				.map(nbt -> new Dynamic<>(NBT_OPS, nbt));
+
+		// Sets the entry
+		final List<Dynamic<?>> copy = new ArrayList<>(stacks);
+		copy.set(column, converted.orElse(EMPTY_STACK));
+		stacks = copy;
+	}
+
+	@Override
+	public ItemStack librarian$getItem(int column)
+	{
+		// Fetch from cache
+		return cache[column];
 	}
 
 	@Unique

--- a/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/HotbarStorageMixin.java
+++ b/1.21.11/src/main/java/me/videogamesm12/librarian/v1_21_11/mixin/HotbarStorageMixin.java
@@ -22,6 +22,7 @@ import com.mojang.serialization.DataResult;
 import me.videogamesm12.librarian.Librarian;
 import me.videogamesm12.librarian.api.HotbarPageMetadata;
 import me.videogamesm12.librarian.api.IWrappedHotbarStorage;
+import me.videogamesm12.librarian.api.IWrappedHotbarStorageEntry;
 import me.videogamesm12.librarian.api.LoadStatus;
 import me.videogamesm12.librarian.api.event.LoadFailureEvent;
 import me.videogamesm12.librarian.api.event.SaveFailureEvent;
@@ -32,6 +33,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.HotbarStorage;
 import net.minecraft.client.option.HotbarStorageEntry;
 import net.minecraft.datafixer.DataFixTypes;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.*;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -328,6 +330,13 @@ public abstract class HotbarStorageMixin implements IWrappedHotbarStorage
 	{
 		Arrays.stream(entries).forEach(entry ->
 				entry.deserialize(Objects.requireNonNull(MinecraftClient.getInstance().world).getRegistryManager()));
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public IWrappedHotbarStorageEntry<ItemStack> librarian$get(int row)
+	{
+		return (IWrappedHotbarStorageEntry<ItemStack>) getSavedHotbar(row);
 	}
 
 	@Unique

--- a/1.21.11/src/main/resources/librarian.v1_21_11.mixins.json
+++ b/1.21.11/src/main/resources/librarian.v1_21_11.mixins.json
@@ -11,6 +11,7 @@
     "ClientPlayNetworkHandlerMixin",
     "CreativeInventoryScreenAccessor",
     "CreativeInventoryScreenMixin",
+    "CreativeScreenHandlerMixin",
     "HandledScreenAccessor",
     "HotbarStorageEntryMixin",
     "HotbarStorageMixin",

--- a/1.21.11/src/main/resources/librarian.v1_21_11.mixins.json
+++ b/1.21.11/src/main/resources/librarian.v1_21_11.mixins.json
@@ -9,6 +9,7 @@
   },
   "client": [
     "ClientPlayNetworkHandlerMixin",
+    "CreativeInventoryScreenAccessor",
     "CreativeInventoryScreenMixin",
     "HandledScreenAccessor",
     "HotbarStorageEntryMixin",

--- a/src/main/java/me/videogamesm12/librarian/api/IWrappedHotbarStorage.java
+++ b/src/main/java/me/videogamesm12/librarian/api/IWrappedHotbarStorage.java
@@ -34,7 +34,7 @@ import java.util.concurrent.CompletableFuture;
  * <p>Wrapper class for HotbarStorage (or, depending on the mappings being used, HotbarManager) instances with extra
  * code for Librarian-specific functions.</p>
  * <p>Because it is impossible to create constructors in classes through mixins, often times this will be implemented
- * into wrapper classes that extend the </p>
+ * into mixin classes for HotbarStorage/HotbarManager.</p>
  */
 public interface IWrappedHotbarStorage
 {
@@ -135,5 +135,10 @@ public interface IWrappedHotbarStorage
 	default void librarian$setMetadata(HotbarPageMetadata metadata)
 	{
 		// Do nothing
+	}
+
+	default <T> IWrappedHotbarStorageEntry<T> librarian$get(int row)
+	{
+		return null;
 	}
 }

--- a/src/main/java/me/videogamesm12/librarian/api/IWrappedHotbarStorageEntry.java
+++ b/src/main/java/me/videogamesm12/librarian/api/IWrappedHotbarStorageEntry.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Video
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.videogamesm12.librarian.api;
+
+/**
+ * <h1>IWrappedHotbarStorageEntry</h1>
+ * <p>Wrapper class for HotbarStorageEntry (or, depending on the mappings being used, Hotbar) instances with extra code
+ * 	for Librarian-specific functions.</p>
+ * @param <C>	ItemStack
+ */
+public interface IWrappedHotbarStorageEntry<C>
+{
+	void librarian$setItem(int column, C value);
+
+	C librarian$getItem(int column);
+}

--- a/src/main/resources/assets/librarian/lang/en_us.json
+++ b/src/main/resources/assets/librarian/lang/en_us.json
@@ -7,6 +7,7 @@
   "librarian.key.next_page": "Next Page",
   "librarian.key.previous_page": "Previous Page",
   "librarian.key.backup_current_page": "Backup Current Page",
+  "librarian.key.delete_item": "Delete Item(s)",
 
   "librarian.saved_hotbars.tab": "Saved Hotbars (Page %1$s)",
   "librarian.saved_toolbars.tab": "Saved Toolbars (Page %1$s)",


### PR DESCRIPTION
Last year, I tried my hand at implementing a drag & drop feature which borrowed a portion of Better Saved Hotbars' source code and tried to evolve it with a shift-click feature as well. It actually worked decently, but there were conflicting ideas as for how such an idea should work and polls I made were divided on what to do, so I put it on the backburner. I eventually closed the relevant pull request as the code changes I was making to the mod at the time were drastic enough to cause compatibility issues.

This pull request is another attempt at implementing such a feature. Here's what's different:

* Instead of using the method that Better Saved Hotbars was using to write entries (spoofing a fake inventory which is kind of a hacky move), we instead bypass the serialize and deserialize methods entirely by adding new methods to HotbarStorageEntry directly for getting and setting items.

* Instead of trying to find a decent compromise for how things should behave, I'm going to instead choose the "my way or the highway" method and make it work how I feel it would work best. This completely eliminates the complications that led to the first implementation being stuck in limbo. My vision for how this works is simple - it tries to emulate vanilla behavior as best as possible by treating saved hotbars almost like a chest. However, to prevent users from accidentally losing items, it'll be intentionally slightly more inconvenient to remove items. You will need to remove them by pressing a keybind like the DELETE key.

This needs to be polished quite a bit more, but so far it's been showing promising results.


