### PR TITLE
Fix crashes caused by backing up hotbars due to illegal characters in the file name caused by the timezone

### DIFF
--- a/src/main/java/me/videogamesm12/librarian/util/FNF.java
+++ b/src/main/java/me/videogamesm12/librarian/util/FNF.java
@@ -104,7 +104,7 @@ public class FNF
 	 */
 	public static String getBackupFileName(BigInteger page)
 	{
-		return String.format("%s [%s].nbt", getPageFileName(page), dateFormat.format(new Date()).replace(":", "-"));
+		return String.format("%s [%s].nbt", getPageFileName(page), dateFormat.format(new Date()));
 	}
 
 	/**

--- a/src/main/java/me/videogamesm12/librarian/util/FNF.java
+++ b/src/main/java/me/videogamesm12/librarian/util/FNF.java
@@ -35,7 +35,7 @@ public class FNF
 	/**
 	 * Date format for use in backups.
 	 */
-	private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd 'at' HH.mm.ss.SSS z");
+	private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd 'at' HH.mm.ss.SSS");
 	/**
 	 * Regex pattern for file names for use in figuring out a hotbar page number from a file.
 	 */
@@ -104,7 +104,7 @@ public class FNF
 	 */
 	public static String getBackupFileName(BigInteger page)
 	{
-		return String.format("%s [%s].nbt", getPageFileName(page), dateFormat.format(new Date()));
+		return String.format("%s [%s].nbt", getPageFileName(page), dateFormat.format(new Date()).replace(":", "-"));
 	}
 
 	/**

--- a/src/main/java/me/videogamesm12/librarian/util/FNF.java
+++ b/src/main/java/me/videogamesm12/librarian/util/FNF.java
@@ -35,7 +35,7 @@ public class FNF
 	/**
 	 * Date format for use in backups.
 	 */
-	private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd 'at' HH.mm.ss.SSS");
+	private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd 'at' HH.mm.ss.SSS Z");
 	/**
 	 * Regex pattern for file names for use in figuring out a hotbar page number from a file.
 	 */


### PR DESCRIPTION
The timezone part of the backup file name apparently causes crashes on Windows due to the `:` in the timezone part of the date formats. This fixes that by using a timezone format that doesn't have the `:` character.